### PR TITLE
feat: index.js now exports printPngFile, added QL-500 to README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ If you need an urgent solution, you can **buy us a $100 coffee** ☕,
 and we’ll fast-track your request to deliver a fix or workaround within 1–2 days.
 
 
-A node.js library built to print png images with Brother Label Printers (QL-710W, QL-720NW, QL-810W, QL-820NWB, QL-1110NWB, QL-1115NWB) connected via USB.
+A node.js library built to print png images with Brother Label Printers (QL-710W, QL-720NW, QL-810W, QL-820NWB, QL-1110NWB, QL-1115NWB, QL-500) connected via USB.
 
 # Installation
 

--- a/index.js
+++ b/index.js
@@ -1,11 +1,5 @@
-//module.exports = require('');
-
 const { printPngFile } = require('./lib/labelPrinter');
 
-printPngFile({
-    vendorId: 0x04f9,
-    productId: 0x209D,
-    filename: './sample.png',
-    options: { landscape: false, labelWidth: "62-mm-wide continuous" },//"102-mm-wide continuous"
-    compression: { enable: true }
-});
+module.exports = {
+    printPngFile
+};


### PR DESCRIPTION
printPngFile was not exported, that caused that the example in the readme did't work

PS: your package works fine with QL-500
